### PR TITLE
Add Symfony 4 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 bin
 composer.lock
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,26 +1,23 @@
 <?php
 
-$finder = Symfony\CS\Finder\DefaultFinder::create()
+$finder = PhpCsFixer\Finder::create()
     ->in('spec/')
     ->in('src/')
 ;
 
-return Symfony\CS\Config\Config::create()
-    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
-    ->fixers(array(
-        'align_double_arrow',
-        'align_equals',
-        'concat_with_spaces',
-        'header_comment',
-        'logical_not_operators_with_spaces',
-        'long_array_syntax',
-        'newline_after_open_tag',
-        'ordered_use',
-        'phpdoc_order',
-        'phpspec',
-        'single_comment_expanded',
-    ))
-    ->addCustomFixer(new PedroTroller\CS\Fixer\Contrib\PhpspecFixer())
-    ->addCustomFixer(new PedroTroller\CS\Fixer\Contrib\SingleCommentExpandedFixer())
-    ->finder($finder)
+return PhpCsFixer\Config::create()
+    ->setFinder($finder)
+    ->setRules([
+        'binary_operator_spaces' => [],
+        'concat_space' => [],
+        'header_comment' => [],
+        'not_operator_with_space' => true,
+        'array_syntax' => [],
+        'linebreak_after_opening_tag' => true,
+        'ordered_imports' => [],
+        'phpdoc_order' => true,
+        'PedroTroller/phpspec' => true,
+        'PedroTroller/single_line_comment' => [],
+    ])
+    ->registerCustomFixers(new PedroTroller\CS\Fixer\Fixers())
 ;

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require-dev": {
         "php": ">=7.0.8",
         "bossa/phpspec2-expect": "~2.0||~3.0",
-        "pedrotroller/php-cs-custom-fixer": "~2.0",
+        "pedrotroller/php-cs-custom-fixer": "~2.17",
         "phpspec/phpspec": "~4.0||~5.0||~6.0",
         "symfony/dependency-injection": "~3.4||~4.3",
         "symfony/event-dispatcher": "~3.4||~4.3"

--- a/composer.json
+++ b/composer.json
@@ -9,15 +9,15 @@
         }
     ],
     "require": {
-        "symfony/security": "~2.6||~3.0"
+        "symfony/security": "~3.4||~4.3"
     },
     "require-dev": {
-        "php": "~7.0",
-        "bossa/phpspec2-expect": "~1.0",
-        "pedrotroller/php-cs-custom-fixer": "~1.3.1",
-        "phpspec/phpspec": "~2.4",
-        "symfony/dependency-injection": "~2.6||~3.0",
-        "symfony/event-dispatcher": "~2.6||~3.0"
+        "php": ">=7.0.8",
+        "bossa/phpspec2-expect": "~2.0||~3.0",
+        "pedrotroller/php-cs-custom-fixer": "~2.0",
+        "phpspec/phpspec": "~4.0||~5.0||~6.0",
+        "symfony/dependency-injection": "~3.4||~4.3",
+        "symfony/event-dispatcher": "~3.4||~4.3"
     },
     "suggest": {
         "knplabs/rad-resource-resolver": "Allows to check authorization against resources resolved from the routing."


### PR DESCRIPTION
php-cs-fixer configuration changed because it has been upgraded from v1 to v2 but the same rule set has been kept.